### PR TITLE
fix: config server when telemetry is undefined

### DIFF
--- a/app/src/app/account/install.component.ts
+++ b/app/src/app/account/install.component.ts
@@ -117,11 +117,11 @@ export class InstallComponent implements OnDestroy {
 
   submitTelemetry() {
     this.apiService
-      .patch('/platform/config', { telemetry: this.telemetry })
+      .patch('/platform/config', { telemetry: !!this.telemetry })
       .subscribe((doc) => {
         this.tabType = InstallPageTabType.Thanks;
         this.apiService._status = undefined;
-        if (doc.url) {
+        if (doc?.url) {
           this.router.navigate(['/account/activate'], {
             queryParams: { key: doc.url }
           });


### PR DESCRIPTION
If the "telemetry" switch is turned off during the initial setup process, the server is not correctly configured because the `telemetry` parameter is not set in the PATCH payload (see https://github.com/trytouca/trytouca/blob/main/api/src/controllers/platform/update.ts#L38-L39). This patch solves the issue by casting the undefined value to boolean.

<img width="496" alt="Screenshot 2022-06-01 at 09 14 00" src="https://user-images.githubusercontent.com/314326/171367831-5bf3d97a-8608-4988-9446-235272e3becf.png">

It also fixes this client-side error when the response is null from the backend:
<img width="464" alt="Screenshot 2022-06-01 at 09 14 20" src="https://user-images.githubusercontent.com/314326/171367826-03cc7971-954c-4100-a69c-3fb987c45c55.png">

