### PR TITLE
server: jwt tokens should always a buffer until expiration time

### DIFF
--- a/api/src/controllers/client/sessionCreate.ts
+++ b/api/src/controllers/client/sessionCreate.ts
@@ -55,11 +55,16 @@ export async function clientSessionCreate(
 
   // edge case:
   // if user has an active unexpired session with matching metadata
-  // provide the same token that we had provided before.
+  // provide the same token that we had provided before. We use a buffer
+  // here to ensure that the time remaining for the token to be expired is long enough
+  // for the test to finish.
+
+  const buffer = new Date()
+  buffer.setHours(buffer.getHours() + (config.auth.jwtLifetimeClient * 24) / 4)
 
   const prevSession = await SessionModel.findOne({
     agent: askedAgent,
-    expiresAt: { $gt: new Date() },
+    expiresAt: { $gt: buffer },
     ipAddr: askedIpAddress,
     userId: user._id
   })


### PR DESCRIPTION
### Motivation

This PR addresses the following user feedback:

> I’ve been continuing my investigation into the intermittent touca server issue, where every so often results are refused by the server. I believe I may have found the issue.
>
> I noticed that when a new client session token is generated [here](https://github.com/trytouca/trytouca/blob/main/api/src/controllers/client/sessionCreate.ts#L79), it uses the “jwtLifetimeClient” configuration setting, which is set to “1” [here](https://github.com/trytouca/trytouca/blob/main/api/src/utils/config.ts#L112), meaning we’re creating a session token that lasts 1 day. I was a bit surprised to see that, as I was under the impression that we are using a 30-day session token, so that alone caught my eye to a degree.
> 
> I then noticed the edge case scenario where if a previous session token exists and the expiration date is greater than the current date, the server should use that instead of generating a new one. But I realized that the check for the expiration date doesn’t give any buffer room. It basically just checks to see if the expiration date is greater than the current time, whether that’s 1 day or 1 minute or 1 second before, as you can see [here](https://github.com/trytouca/trytouca/blob/main/api/src/controllers/client/sessionCreate.ts#L62).
>
> So my guess is that because we’re running our tests at the same time every day, there are some days where the test runs and the current session token expiration date is less than the current date, so we create a new token and the full test will run without issue, while there are other days where the current session token expiration date is greater than the current date, but only by a little bit, so the test will use the current token for the couple minutes that it is still active, and then all subsequent results will be refused since the token will have expired.
>
> So I think a possible solution to this would be to add a buffer to the check for a previous session token (maybe a quarter of a day or a half a day or something) at [this spot](https://github.com/trytouca/trytouca/blob/main/api/src/controllers/client/sessionCreate.ts#L62). Then we would be guaranteed to have enough time for the full test to finish before the current existing session token expires.
>
> Does that all make sense? I’d be happy to discuss this with you anytime.

