### PR TITLE
build: reduce docker image size (#311)

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -11,8 +11,10 @@ RUN apk add --no-cache curl \
     && npm i -g pnpm \
     && mkdir -p /opt/touca/api/certs \
     && curl -o /opt/touca/api/certs/cert.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \
-    && pnpm --dir=/opt/touca/api install --filter=@touca/api --filter=@touca/api-schema --filter=@touca/comparator --filter=@touca/flatbuffers --no-strict-peer-dependencies \
-    && pnpm --dir=/opt/touca/api run build
+    && pnpm --dir=/opt/touca/api --filter=@touca/api --filter=@touca/api-schema --filter=@touca/comparator --filter=@touca/flatbuffers install --no-strict-peer-dependencies --ignore-scripts \
+    && pnpm --dir=/opt/touca/api -r --filter=@touca/api --filter=@touca/api-schema --filter=@touca/comparator --filter=@touca/flatbuffers run build \
+    && find /opt/touca -maxdepth 3 -name 'node_modules' -type d | xargs rm -rf \
+    && pnpm --dir=/opt/touca/api  --filter=@touca/api --filter=@touca/api-schema --filter=@touca/comparator --filter=@touca/flatbuffers install --prod --no-strict-peer-dependencies --ignore-scripts
 
 # ---- builder stage (app) ----
 


### PR DESCRIPTION
Final image size: 450MB -> 168MB
Build time (without cache) on my machine: basically equal

Overview: 
In `builder_api` stage, install all dependencies for the 4 needed modules, build them, recursively delete all `node_modules`, and re-install with `--prod`.  Setting `--ignore-scripts` on `install` disables the `postinstall` scripts on packages in `<repository>/packages/*`, since their build step is now handled by `pnpm`.  Without this, the image will fail to build, since `packages/*` will try to rebuild themselves with `devDependencies` that are no longer installed.

QA:
I was able to build the image locally and run it against local Mongo/Redis/MinIO instances without any issue.  I ran through the onboarding flow with the web app running against this container, and loaded sample data, also without issue.  I was *not* able to get the server to load `.env.production` with `docker run --env environment=production`, and so I wasn't able to test that the app bundle was being served correctly, which I assume is important for this container.  There's probably something obvious I'm missing.  Let me know if there's a good way for me to check this, or if there's anything else I can change/provide!

