### PR TITLE
server: configure eslint rule for ts-expect-error

### DIFF
--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -21,6 +21,14 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "@typescript-eslint/ban-ts-comment": [
+          "error",
+          {
+            "ts-expect-error": {
+              "descriptionFormat": "^: TS2339 because .+$"
+            }
+          }
+        ],
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -26,8 +26,7 @@ function registerMiddlewares(app: express.Express) {
       express.static(config.webapp.distDirectory, {
         maxAge: '1d',
         setHeaders: (res, path) => {
-          // @ts-ignore express's static middleware uses mime v1.6.0
-          // https://www.npmjs.com/package/mime/v/1.6.0#api---queries
+          // @ts-expect-error: TS2339 because library definitions are wrong
           if (express.static.mime.lookup(path) === 'text/html') {
             res.setHeader('Cache-Control', 'public, max-age=0')
           }


### PR DESCRIPTION
Per this use case: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-ts-comment.md#descriptionformat