### PR TITLE
sdk-python: verify credentials during configuration

### DIFF
--- a/api/src/controllers/client/verify.ts
+++ b/api/src/controllers/client/verify.ts
@@ -1,7 +1,8 @@
+// Copyright 2023 Touca, Inc. Subject to Apache-2.0 License.
+
 import { NextFunction, Request, Response } from 'express'
 
 import { TeamModel, UserModel } from '../../schemas/index.js'
-import { logger } from '../../utils/index.js'
 
 export async function clientVerify(
   req: Request,
@@ -9,65 +10,43 @@ export async function clientVerify(
   next: NextFunction
 ) {
   const inputApiKey = req.header('x-touca-api-key')
-
   if (!inputApiKey) {
-    logger.debug('client api key not provided')
     return next({
-      errors: ['API Key is required.'],
+      errors: ['api key missing'],
       status: 401
     })
   }
-
-  const user = await UserModel.findOne({
-    apiKeys: inputApiKey,
-    suspended: false,
-    lockedAt: { $exists: false }
-  })
-
+  const user = await UserModel.findOne(
+    {
+      apiKeys: inputApiKey,
+      suspended: false,
+      lockedAt: { $exists: false }
+    },
+    { _id: 1, username: 1 }
+  )
   if (!user) {
-    logger.debug('%s: client api key is invalid', inputApiKey)
     return next({
-      errors: ['API Key is invalid.'],
+      errors: ['api key invalid'],
       status: 401
     })
   }
-
-  logger.info('%s: client verified with api key', user.username)
-
-  const inputTeamSlug = req.query.team
-
-  if (!inputTeamSlug) {
-    return res.status(204).end()
-  }
-
-  const team = await TeamModel.findOne({
-    slug: inputTeamSlug,
-    suspended: false
-  })
-
-  if (!team) {
-    logger.debug('%s: client team does not exist', inputTeamSlug)
-    return next({
-      errors: [`Team "${inputTeamSlug}" does not exist.`],
-      status: 400
+  const inputTeamSlug = req.body?.team
+  if (inputTeamSlug) {
+    const hasTeam = await TeamModel.countDocuments({
+      slug: inputTeamSlug,
+      suspended: false,
+      $or: [
+        { members: { $in: user._id } },
+        { admins: { $in: user._id } },
+        { owner: user._id }
+      ]
     })
+    if (!hasTeam) {
+      return next({
+        errors: ['team unauthorized'],
+        status: 403
+      })
+    }
   }
-
-  const isUserPlatformAdmin =
-    user.platformRole === 'owner' || user.platformRole === 'admin'
-
-  const isUserTeamMember =
-    team.members.includes(user._id) ||
-    team.admins.includes(user._id) ||
-    team.owner.equals(user._id)
-
-  if (!isUserPlatformAdmin && !isUserTeamMember) {
-    logger.debug('%s: client not authorized to access team', inputTeamSlug)
-    return next({
-      errors: [`User is not authorized to access team "${inputTeamSlug}".`],
-      status: 403
-    })
-  }
-
-  return res.status(204).end()
+  return res.status(204).send()
 }

--- a/api/src/routes/client.ts
+++ b/api/src/routes/client.ts
@@ -75,6 +75,6 @@ router.post(
   standby(clientSubmitArtifact, 'handle submitted artifact')
 )
 
-router.get('/verify', standby(clientVerify, 'verify API credentials'))
+router.post('/verify', standby(clientVerify, 'verify configuration options'))
 
 export { router as clientRouter }

--- a/packages/api-schema/src/schema.yaml
+++ b/packages/api-schema/src/schema.yaml
@@ -1849,6 +1849,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Errors'
+  /client/verify:
+    post:
+      tags:
+        - Client
+      summary: Check SDK configuration options including API Key
+      operationId: client_verify
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                team:
+                  type: string
+        required: false
+      responses:
+        '204':
+          description: Configuration options are valid
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /comment/:team/:suite/:batch/c:
     get:
       tags:

--- a/sdk/python/touca/cli/results/post.py
+++ b/sdk/python/touca/cli/results/post.py
@@ -105,7 +105,7 @@ class PostCommand(CliCommand):
         apply_environment_variables(options)
         apply_api_url(options)
         apply_core_options(options)
-        transport.configure(*map(options.get, ["api_url", "api_key"]))
+        transport.configure(options)
 
         results_tree = build_results_tree(src_dir)
         errors = _post_binary_files(transport, results_tree)


### PR DESCRIPTION
This is an improvement to #491 that added `/client/verify` but was never using it anywhere. The idea behind `/client/verify` is to validate API credentials (as well as other configuration options in the future) before proceeding with the execution of the test. This call needs to happen regardless of whether the user is using the low-level api `touca.configure` or the high-level api `touca.run` which invokes `update_runner_options`. I moved the call back into `transport.configure` because we don't want to repeat calling this endpoint if `touca.configure` is called multiple times but the `api_key` and `api_url` have not changed. I'm also changed `/client/verify` to accept POST instead of GET with the idea that we may want to submit the entire config options to the server in the future (for analytics and for validation).