### PR TITLE
add workflows for releasing helm chart

### DIFF
--- a/.github/configs/cr.yaml
+++ b/.github/configs/cr.yaml
@@ -1,0 +1,2 @@
+## Reference: https://github.com/helm/chart-releaser
+index-path: "./index.yaml"

--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -1,0 +1,15 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Install Stage
+remote: origin
+chart-dirs:
+  - ops/k8s
+chart-repos:
+  - touca=https://trytouca.github.io/trytouca
+helm-extra-args: "--timeout 600s"  
+validate-chart-schema: false
+validate-maintainers: true
+validate-yaml: true
+exclude-deprecated: true
+target-branch: main
+excluded-charts: []

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -1,0 +1,15 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Lint Stage
+remote: origin
+chart-dirs:
+  - ops/k8s
+chart-repos:
+  - touca=https://trytouca.github.io/trytouca
+helm-extra-args: "--timeout 600s"  
+validate-chart-schema: false
+validate-maintainers: true
+validate-yaml: true
+exclude-deprecated: true
+target-branch: main
+excluded-charts: []

--- a/.github/configs/lintconf.yaml
+++ b/.github/configs/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  document-end: disable
+  document-start: disable # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,45 @@
+## Reference: https://github.com/helm/chart-testing-action
+---
+name: Helm Chart Linting and Testing
+on: pull_request
+jobs: 
+  chart-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: List changed charts
+        id: list-changed
+        run: |
+          ## If executed with debug this won't work anymore.
+          changed=$(ct --config ./.github/configs/ct-lint.yaml list-changed)
+          charts=$(echo "$changed" | tr '\n' ' ' | xargs)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+            echo "::set-output name=changed_charts::$charts"
+          fi
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ./.github/configs/ct-install.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+---
+name: Publish Helm Chart
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"  
+          
+      ## This is required to consider the old Circle-CI Index and to stay compatible with all the old releases.
+      - name: Fetch current Chart Index 
+        run: |
+          git checkout origin/gh-pages index.yaml
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        with: 
+          config: "./.github/configs/cr.yaml"
+          charts_dir: ops/k8s
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR publishes the Helm chart using GitHub pages on the current repo, making it easier for people to install. This way we at Plural can more easily keep the Touca installation up to date with the helm chart in this repository. For an example of how the repo will look after this you can have a look at our fork. https://github.com/pluralsh/trytouca

For this to work a new `gh-pages` branch needs to be created with the following 2 files before merging this PR:

`index.html`:
```html
<html>
  <head>
    <title>Touca charts repository</title>
  </head>
  <body>
    <h1>Touca charts repository</h1>
    <p>Add this repository</p>
    <pre>
      helm repo add argo https://trytouca.github.io/trytouca
    </pre>
  </body>
</html>
```

`index.yaml`:
```yaml
apiVersion: v1
entries: {}
generated: ""
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204723999139649