### PR TITLE
sdk-python: remove upper bound on `certifi`

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-certifi = "^2022.12.7"
+certifi = ">=2022.12.7"
 flatbuffers = "^23.1.4"
 rich = ">=12.6.0"
 touca-fbs = "^0.0.3"


### PR DESCRIPTION
Just allowing latest `certifi` versions, which follows calver and not semver
